### PR TITLE
Add Deploy to Heroku button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -jar -Xmx256M ./target/github-profile-summary-jar-with-dependencies.jar

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ You can enable Google Tag Manager on your instance by setting `gtm-id`:
 * `docker run -it --rm --name github-profile-summary -p 7070:7070 github-profile-summary`
 * OR with a token `docker run -it --rm --name github-profile-summary -p 7070:7070 -e "API_TOKENS=mytoken1,mytoken2" github-profile-summary`
 * browse to http://localhost:7070
+
+## run on Heroku (for free)
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)

--- a/app.json
+++ b/app.json
@@ -1,0 +1,21 @@
+{
+  "name": "GitHub Profile Summary",
+  "description": "Tool for visualizing GitHub profiles",
+  "website": "https://github-profile-summary.com/",
+  "repository": "https://github.com/tipsy/github-profile-summary",
+  "env": {
+    "API_TOKENS": {
+      "description": "If no api-token is set, you only get ~50 requests/hour. Generate a token at https://github.com/settings/tokens, and input here. You can use a comma-separated list of tokens to increase your rate-limit.",
+      "required": false
+    },
+    "UNRESTRICTED": {
+      "description": "Allow profile summary to be built for any GitHub profile. Summary creation of large profiles can quickly consume your API request limit.",
+      "required": false,
+      "value": "false"
+    },
+    "GTM_ID": {
+      "description": "Provide a Google Tag Manager ID to enable GTM.",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
Cool project 👏 ! I thought I'd add a "Deploy to Heroku" button so others can deploy their own version easily.

Click on the deploy button will take you [here](https://heroku.com/deploy?template=https://github.com/crcastle/github-profile-summary) to kick-off the deploy.