### PR TITLE
Improve performance and accuracy of new star check approach

### DIFF
--- a/src/main/kotlin/app/UserCtrl.kt
+++ b/src/main/kotlin/app/UserCtrl.kt
@@ -50,11 +50,12 @@ object UserCtrl {
     }
 
     fun hasStarredRepo(username: String): Boolean {
-        if (watchers.contains(username))
+        val login = username.toLowerCase()
+        if (watchers.contains(login))
             return true
 
         syncWatchers()
-        return watchers.contains(username)
+        return watchers.contains(login)
     }
 
     fun syncWatchers() {

--- a/src/main/kotlin/app/UserCtrl.kt
+++ b/src/main/kotlin/app/UserCtrl.kt
@@ -8,12 +8,12 @@ import org.slf4j.LoggerFactory
 import java.io.Serializable
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
+import java.util.stream.IntStream
 import kotlin.streams.toList
 
 object UserCtrl {
 
     private val log = LoggerFactory.getLogger("app.UserCtrlKt")
-
     private val repo = GhService.repos.getRepository("tipsy", "profile-summary-for-github")
     private val watchers = ConcurrentHashMap.newKeySet<String>()
 
@@ -50,17 +50,24 @@ object UserCtrl {
     }
 
     fun hasStarredRepo(username: String): Boolean {
-        addAllWatchers(pageNumber = watchers.size / 100 + 1)
-        return watchers.find { it == username.toLowerCase() } != null
+        if (watchers.contains(username))
+            return true
+
+        syncWatchers()
+        return watchers.contains(username)
     }
 
-    fun initWatcherSet() {
-        val lastPage = repo.watchers / 100 + 1
-        (0..lastPage).toList().parallelStream().forEach { page -> addAllWatchers(page) }
+    fun syncWatchers() {
+        val realWatchers = repo.watchers
+        if (watchers.size < realWatchers) {
+            val startPage = watchers.size / 100 + 1
+            val lastPage = realWatchers / 100 + 1
+            IntStream.rangeClosed(startPage, lastPage).parallel().forEach { page -> addAllWatchers(page) }
+        }
     }
 
     private fun addAllWatchers(pageNumber: Int) = try {
-        watchers.addAll(GhService.watchers.pageWatchers(repo, pageNumber, 100).first().map { it.login.toLowerCase() })
+        GhService.watchers.pageWatchers(repo, pageNumber, 100).first().forEach { watchers.add(it.login.toLowerCase()) }
     } catch (e: Exception) {
         log.info("Exception while adding watchers", e)
     }


### PR DESCRIPTION
Closes #87.

* Incorporates #88 (Cache property lookups for canLoadUser(String))
* Lookup usernames in cache in O(1) time by saving lowercase version (rather than O(n) of Iterable#find)
* Don't bother with requesting extra pages if we have already cached the username
* Don't request full last page if there are no extra watchers on the page
* Request all pages since the last grabbed page instead of just the last page (solves a rare edge case now that traffic has lowered)
* Don't allocate unneeded lists (some memory gain)
