### PR TITLE
Cache improvements

### DIFF
--- a/src/main/kotlin/app/Cache.kt
+++ b/src/main/kotlin/app/Cache.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.Executors
 object Cache {
 
     private const val path = "cache/userinfo"
-    private val userProfiles = ConcurrentHashMap(readUserProfilesFromDisk())
+    private val userProfiles = readUserProfilesFromDisk()
     private val fileSaveExecutor = Executors.newSingleThreadExecutor()
 
     // Put userProfile in cache, then serialize cache and write it to disk
@@ -37,22 +37,22 @@ object Cache {
 
     // Read cache from disk, return empty map if no cache file exists
     @Suppress("UNCHECKED_CAST")
-    private fun readUserProfilesFromDisk(): MutableMap<String, UserProfile> {
+    private fun readUserProfilesFromDisk(): ConcurrentHashMap<String, UserProfile> {
         try {
             File(path).apply {
                 if (exists()) {
                     ObjectInputStream(ByteArrayInputStream(readBytes())).let {
                         val obj = it.readObject()
 
-                        if (obj is MutableMap<*, *>)
-                            return obj as MutableMap<String, UserProfile>
+                        if (obj is ConcurrentHashMap<*, *>)
+                            return obj as ConcurrentHashMap<String, UserProfile>
                     }
                 }
             }
         } catch (e: Exception) {
         }
 
-        return mutableMapOf()
+        return ConcurrentHashMap()
     }
 
 }

--- a/src/main/kotlin/app/Cache.kt
+++ b/src/main/kotlin/app/Cache.kt
@@ -3,23 +3,29 @@ package app
 import java.io.*
 import java.time.Instant
 import java.time.temporal.ChronoUnit.HOURS
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
 
 object Cache {
 
     private const val path = "cache/userinfo"
-    private val userProfiles = readUserProfilesFromDisk()
+    private val userProfiles = ConcurrentHashMap(readUserProfilesFromDisk())
+    private val fileSaveExecutor = Executors.newSingleThreadExecutor()
 
     // Put userProfile in cache, then serialize cache and write it to disk
     fun putUserProfile(userProfile: UserProfile) {
         userProfiles[userProfile.user.login.toLowerCase()] = userProfile
-        val byteArrayOutputStream = ByteArrayOutputStream()
-        ObjectOutputStream(byteArrayOutputStream).writeObject(userProfiles)
-        File(path).apply {
-            if (!exists()) {
-                parentFile.mkdirs()
-                createNewFile()
+        fileSaveExecutor.execute {
+            ByteArrayOutputStream().let {
+                ObjectOutputStream(it).writeObject(userProfiles)
+                File(path).apply {
+                    if (!exists()) {
+                        parentFile.mkdirs()
+                        createNewFile()
+                    }
+                    writeBytes(it.toByteArray())
+                }
             }
-            writeBytes(byteArrayOutputStream.toByteArray())
         }
     }
 
@@ -31,12 +37,22 @@ object Cache {
 
     // Read cache from disk, return empty map if no cache file exists
     @Suppress("UNCHECKED_CAST")
-    private fun readUserProfilesFromDisk(): MutableMap<String, UserProfile> = if (File(path).exists()) {
-        ObjectInputStream(
-                ByteArrayInputStream(File("cache/userinfo").readBytes())
-        ).readObject() as MutableMap<String, UserProfile>
-    } else {
-        mutableMapOf()
+    private fun readUserProfilesFromDisk(): MutableMap<String, UserProfile> {
+        try {
+            File(path).apply {
+                if (exists()) {
+                    ObjectInputStream(ByteArrayInputStream(readBytes())).let {
+                        val obj = it.readObject()
+
+                        if (obj is MutableMap<*, *>)
+                            return obj as MutableMap<String, UserProfile>
+                    }
+                }
+            }
+        } catch (e: Exception) {
+        }
+
+        return mutableMapOf()
     }
 
 }


### PR DESCRIPTION
Storage
* Queue up storage tasks to a separate thread for file i/o
* Use a ConcurrentHashMap in case of simultaneous profile saves (was a non-synchronized LinkedHashMap)


Retrieval
* Use `let` to auto close resources
* Better exception handling (mostly relevant when serial version uid changes)


Reading
* ConcurrentHashMap uses less memory than LinkedHashMap
* Map#get on ConcurrentHashMap is faster
