### PR TITLE
Make Clicking "Unknown" Language Do Nothing.

### DIFF
--- a/src/main/resources/vue/components/_charts.vue
+++ b/src/main/resources/vue/components/_charts.vue
@@ -1,4 +1,6 @@
 <script>
+    const UNKNOWN_LANGUAGE = "Unknown";
+
     function donutChart(objectName, data) {
         let canvas = document.getElementById(objectName);
         if (canvas === null) {
@@ -6,6 +8,12 @@
         }
         let userId = data.user.login;
         let labels = Object.keys(data[objectName]);
+
+        /**
+         * The language index of <code>UNKNOWN_LANGUAGE</code>
+         * @type {Number}
+         */
+        let indexOfUnknownLanguage = -1;
         let values = Object.values(data[objectName]);
         let colors = createColorArray(labels.length);
         let tooltipInfo = null;
@@ -17,6 +25,7 @@
         if (["langRepoCount", "langStarCount", "langCommitCount"].indexOf(objectName) > -1) {
             // if the dataset is language-related, load color-profile
             labels.forEach((language, i) => colors[i] = languageColors[language]);
+            indexOfUnknownLanguage = labels.indexOf(UNKNOWN_LANGUAGE);
         }
         if (objectName === "repoCommitCount") {
             tooltipInfo = data[objectName + "Descriptions"]; // high quality programming
@@ -52,19 +61,26 @@
                             if (tooltipInfo !== null) {
                                 return wordWrap(tooltipInfo[data["labels"][tooltipItem["index"]]], 45);
                             }
+
+                            if (tooltipItem.index === indexOfUnknownLanguage) {
+                                return "No specific language";
+                            }
                         }
                     },
                 },
                 onClick: function (e, data) {
                     try {
                         let label = labels[data[0]._index];
+                        const isUnknownLanguage = (data[0]._index === indexOfUnknownLanguage);
                         let canvas = data[0]._chart.canvas.id;
                         if (canvas === "repoStarCount" || canvas === "repoCommitCount") {
                             window.open("https://github.com/" + userId + "/" + label, "_blank");
                             window.focus();
                         } else {
-                            window.open("https://github.com/" + userId + "?utf8=%E2%9C%93&tab=repositories&q=&type=source&language=" + encodeURIComponent(label), "_blank");
-                            window.focus();
+                            if (!isUnknownLanguage) {
+                                window.open("https://github.com/" + userId + "?utf8=%E2%9C%93&tab=repositories&q=&type=source&language=" + encodeURIComponent(label), "_blank");
+                                window.focus();
+                            }
                         }
                     } catch (ignored) {
                     }


### PR DESCRIPTION
It's a possible solution to #97.

`Unknown` here is actually a [representation of null](https://github.com/tipsy/profile-summary-for-github/blob/master/src/main/kotlin/app/UserService.kt#L42).

Passing query string `language=Unknown` (or any arbitrary language) to the user *repositories* tab is currently equivalent to passing none, so I decided not to open anything when `Unknown` is clicked.

Plus, I added some text to the tooltip in order to prevent confusion:
![image](https://user-images.githubusercontent.com/66462458/166422608-ebe2516f-a3f7-4ec4-8171-0cd97ad96d7c.png)
![image](https://user-images.githubusercontent.com/66462458/166422616-05b4e9b5-1bed-439f-a48d-594c2aa698f6.png)
![image](https://user-images.githubusercontent.com/66462458/166422626-a21f098b-2074-42cf-a1f2-447f8d774efd.png)
Those screenshots are taken from @ajmeese7's profile summary. 😁

I suppose it's safe until a language named *Unknown* gets popular enough.