### PR TITLE
Remove Unnecessary Legend Labels

### DIFF
--- a/src/main/kotlin/app/UserService.kt
+++ b/src/main/kotlin/app/UserService.kt
@@ -90,7 +90,7 @@ object UserService {
 
         val quarterCommitCount = CommitCountUtil.getCommitsForQuarters(user, repoCommits)
         val langRepoCount = langRepoGrouping.eachCount().toList().sortedBy { (_, v) -> -v }.toMap()
-        val langStarCount = langRepoGrouping.fold(0) { acc, repo -> acc + repo.watchers }.toList().sortedBy { (_, v) -> -v }.toMap()
+        val langStarCount = langRepoGrouping.fold(0) { acc, repo -> acc + repo.watchers }.toList().filter { (_, v) -> v > 0 }.sortedBy { (_, v) -> -v }.toMap()
         val langCommitCount = langRepoGrouping.fold(0) { acc, repo -> acc + repoCommits[repo]!!.size }.toList().sortedBy { (_, v) -> -v }.toMap()
         val repoCommitCount = repoCommits.map { it.key.name to it.value.size }.toList().sortedBy { (_, v) -> -v }.take(10).toMap()
         val repoStarCount = repos.filter { it.watchers > 0 }.map { it.name to it.watchers }.sortedBy { (_, v) -> -v }.take(10).toMap()


### PR DESCRIPTION
Simply adds a filtration process to `langStarCount`.

It fixes #114.

![image](https://user-images.githubusercontent.com/66462458/173490089-e616410a-afc0-4f45-9221-4041976414d1.png)
↓
![image](https://user-images.githubusercontent.com/66462458/173490961-281b8f8e-5c4e-4064-9e3b-522412d0d6b9.png)
